### PR TITLE
adds basic support for google calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ typings/
 .env
 
 parameters.js
+.credentials
+config/*.json

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 A cli js script to list your recent activity on Trello and GitHub
 
+
+# Configure Google Calendar
+
+1. Use [this wizard](https://console.developers.google.com/start/api?id=calendar) to create or select a project in the Google Developers Console and automatically turn on the API. Click Continue, then Go to credentials.
+2. On the Add credentials to your project page, click the Cancel button.
+3. At the top of the page, select the OAuth consent screen tab. Select an Email address, enter a Product name if not already set, and click the Save button.
+4. Select the Credentials tab, click the Create credentials button and select OAuth client ID.
+5. Select the application type Other, enter the name "Google Calendar API Quickstart", and click the Create button.
+6. Click OK to dismiss the resulting dialog.
+7. Click the file_download (Download JSON) button to the right of the client ID.
+8. Move this file to ./config directory and rename it gcal_client_secret.json.
+
+
 # Running Lethe:
 
 - Clone project and install dependencies:
@@ -11,3 +24,5 @@ A cli js script to list your recent activity on Trello and GitHub
 
 - Run Lethe:
 ```npm start```
+
+

--- a/gcal/plugin.js
+++ b/gcal/plugin.js
@@ -1,0 +1,142 @@
+var fs = require('fs');
+var readline = require('readline');
+var google = require('googleapis');
+var googleAuth = require('google-auth-library');
+var prettyDate = require('../pretty_date');
+
+// If modifying these scopes, delete your previously saved credentials
+// at ~/.credentials/gcal-lethe.json
+var SCOPES = ['https://www.googleapis.com/auth/calendar.readonly'];
+var TOKEN_DIR = (process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE) + '/.credentials/';
+var TOKEN_PATH = TOKEN_DIR + 'gcal-lethe.json';
+
+
+function run(baseDir)
+{
+  if (baseDir) {
+    TOKEN_DIR = baseDir + '/.credentials/';
+    TOKEN_PATH = TOKEN_DIR + 'gcal-lethe.json';
+  }
+
+  // Load client secrets from a local file.
+  fs.readFile('config/gcal_client_secret.json', function processClientSecrets(err, content) {
+    if (err) {
+      console.error('Error loading client secret file: ' + err);
+      return;
+    }
+    // Authorize a client with the loaded credentials, then call the
+    // Google Calendar API.
+    authorize(JSON.parse(content), listLastTwoWeeksEvents);
+  });
+}
+
+/**
+ * Create an OAuth2 client with the given credentials, and then execute the
+ * given callback function.
+ *
+ * @param {Object} credentials The authorization client credentials.
+ * @param {function} callback The callback to call with the authorized client.
+ */
+function authorize(credentials, callback) {
+  var clientSecret = credentials.installed.client_secret;
+  var clientId = credentials.installed.client_id;
+  var redirectUrl = credentials.installed.redirect_uris[0];
+  var auth = new googleAuth();
+  var oauth2Client = new auth.OAuth2(clientId, clientSecret, redirectUrl);
+
+  // Check if we have previously stored a token.
+  fs.readFile(TOKEN_PATH, function(err, token) {
+    if (err) {
+      getNewToken(oauth2Client, callback);
+    } else {
+      oauth2Client.credentials = JSON.parse(token);
+      callback(oauth2Client);
+    }
+  });
+}
+
+/**
+ * Get and store new token after prompting for user authorization, and then
+ * execute the given callback with the authorized OAuth2 client.
+ *
+ * @param {google.auth.OAuth2} oauth2Client The OAuth2 client to get token for.
+ * @param {getEventsCallback} callback The callback to call with the authorized
+ *     client.
+ */
+function getNewToken(oauth2Client, callback) {
+  var authUrl = oauth2Client.generateAuthUrl({
+    access_type: 'offline',
+    scope: SCOPES
+  });
+  console.log('Authorize this app by visiting this url: ', authUrl);
+  var rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+  rl.question('Enter the code from that page here: ', function(code) {
+    rl.close();
+    oauth2Client.getToken(code, function(err, token) {
+      if (err) {
+        console.error('Error while trying to retrieve access token', err);
+        return;
+      }
+      oauth2Client.credentials = token;
+      storeToken(token);
+      callback(oauth2Client);
+    });
+  });
+}
+
+/**
+ * Store token to disk be used in later program executions.
+ *
+ * @param {Object} token The token to store to disk.
+ */
+function storeToken(token) {
+  try {
+    fs.mkdirSync(TOKEN_DIR);
+  } catch (err) {
+    if (err.code != 'EEXIST') {
+      throw err;
+    }
+  }
+  fs.writeFile(TOKEN_PATH, JSON.stringify(token));
+  console.log('Token stored to ' + TOKEN_PATH);
+}
+
+/**
+ * Lists the next 10 events on the user's primary calendar.
+ *
+ * @param {google.auth.OAuth2} auth An authorized OAuth2 client.
+ */
+function listLastTwoWeeksEvents(auth) {
+  var calendar = google.calendar('v3');
+  var firstEventDate = new Date();
+  firstEventDate.setDate(firstEventDate.getDate() - 15);
+  calendar.events.list({
+    auth: auth,
+    calendarId: 'primary',
+    timeMin: firstEventDate.toISOString(),
+    timeMax: (new Date()).toISOString(),
+    maxResults: 20,
+    singleEvents: true,
+    orderBy: 'startTime'
+  }, function(err, response) {
+    if (err) {
+      console.log('The API returned an error: ' + err);
+      return;
+    }
+    var events = response.items;
+    if (events.length == 0) {
+      console.log('No upcoming events found in Google Calendar.');
+    } else {
+      for (var i = 0; i < events.length; i++) {
+        var event = events[i];
+        var start = event.start.dateTime || event.start.date;
+        console.log(prettyDate(start)+":", event.summary);
+      }
+    }
+  });
+}
+
+exports.run = run

--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ var Promise = require('bluebird');
 var githubUsername = null;
 var githubPassword = null;
 
+var prettyDate = require('./pretty_date');
+var gcal = require('./gcal/plugin');
+
+
 if (!params.trelloApiToken) {
   console.log(
     "You need to set your trelloApiToken in parameters.js ",
@@ -12,8 +16,10 @@ if (!params.trelloApiToken) {
   );
   return;
 }
+
 var Trello = require("node-trello");
 var t = new Trello(params.trelloApiKey, params.trelloApiToken);
+
 
 function printTrelloEvents () {
   t.get("/1/members/me/actions", function (err, data) {
@@ -60,13 +66,6 @@ function printCardMoved (item) {
     " to " + item.data.listAfter.name.toUpperCase());
 }
 
-function prettyDate (date) {
-  var months = ["jan", "feb", "mar", "apr", "may", "jun",
-    "jul", "aug", "sep", "oct", "nov", "dec"
-  ];
-
-  return date.substr(8, 2) + months[parseInt(date.substr(5, 2) - 1)];
-}
 
 function addEmptyLineIfNewDay (prevDate, currDate) {
   if (prevDate.substr(8, 2) != currDate.substr(8, 2)) {
@@ -75,8 +74,8 @@ function addEmptyLineIfNewDay (prevDate, currDate) {
 }
 
 
-function printGithubEvents () {
-
+function printGithubEvents () 
+{
   var github = new GitHubApi({
     debug: false,
     Promise: Promise,
@@ -119,6 +118,11 @@ function printGithubEvents () {
   });
 }
 
+function printGcalEvents()
+{
+  gcal.run(__dirname);
+}
+
 function printError(error) {
   console.error('ERROR:',error);
 }
@@ -148,6 +152,8 @@ function getCredentials () {
   printTrelloEvents();
   console.log();
   printGithubEvents();
+  console.log();
+  printGcalEvents();
 }
 
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "github": "^11.0.0",
+    "google-auth-library": "^0.11.0",
+    "googleapis": "^22.2.0",
     "node-trello": "^1.3.0",
     "readline-sync": "^1.4.7"
   },

--- a/pretty_date.js
+++ b/pretty_date.js
@@ -1,0 +1,9 @@
+function prettyDate (date) {
+    var months = ["jan", "feb", "mar", "apr", "may", "jun",
+      "jul", "aug", "sep", "oct", "nov", "dec"
+    ];
+  
+    return date.substr(8, 2) + months[parseInt(date.substr(5, 2) - 1)];
+}
+
+module.exports = prettyDate


### PR DESCRIPTION
Code here should be better reorganized and refactored to be considered "readable", but it's the MVP of a gcal addon.
Some method used here for credentials management could be used for github too.
Resolves #3 but let's talk about this